### PR TITLE
prolly...so it wont break

### DIFF
--- a/linuxclientinstall.sh
+++ b/linuxclientinstall.sh
@@ -60,7 +60,7 @@ case ${OS,,} in
 esac
 
 rustdesk --password ${admintoken}
-pkill -f "rustdesk"
+sudo pkill -f "rustdesk"
 
 # Setup Rustdesk in user profile
 rustdesktoml2a="$(cat << EOF
@@ -94,10 +94,10 @@ EOF
 )"
 echo "${rustdesktoml2b}" | sudo tee /root/.config/rustdesk/RustDesk2.toml > /dev/null
 
-chown ${uname}:${uname} /home/${uname}/.config/rustdesk/RustDesk2.toml
+sudo chown ${uname}:${uname} /home/${uname}/.config/rustdesk/RustDesk2.toml
 
 
-systemctl restart rustdesk
+sudo systemctl restart rustdesk
 
 echo "ID & Password for Rustdesk ${uname} are:"
 grep -w id /home/${uname}/.config/rustdesk/RustDesk.toml


### PR DESCRIPTION
as i understand this shall be executed by an administrator on the clients, but without root sudo, the commands are unsuccessful.
also on line 97, the `${uname}:${uname}` makes sense on most single user systems, but on a working enviroment, where multiple people login on a PC via ldap, by default users are on in the group, named the same as the username.......so that breaks as well but did no change it...yet, for me `${uname}:sudo` worked
(tried on ubuntu 20)