### PR TITLE
little refactoring and cleaner powershell 

### DIFF
--- a/WindowsAgentAIOInstall.ps1
+++ b/WindowsAgentAIOInstall.ps1
@@ -39,7 +39,7 @@ If (!(Test-Path "$env:ProgramFiles\Rustdesk\RustDesk.exe")) {
 
   Expand-Archive rustdesk.zip
   cd rustdesk
-  start .\rustdesk-$restdesk_version-putes.exe --silent-install
+  Start .\rustdesk-$restdesk_version-putes.exe --silent-install
 
   # Set URL Handler
   New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk" > null
@@ -55,8 +55,8 @@ If (!(Test-Path "$env:ProgramFiles\Rustdesk\RustDesk.exe")) {
   $rustdesklauncher = '"' + $env:ProgramFiles + '\RustDesk\RustDeskURLLauncher.exe" %1"'
   Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell\open\command" -Name "(Default)" -Value $rustdesklauncher > null
 
-  Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force  > null
-  Install-Module ps2exe -Force  > null
+  Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force > null
+  Install-Module ps2exe -Force > null
 
 $urlhandler_ps1 = @"
   `$url_handler = `$args[0]
@@ -67,13 +67,14 @@ $urlhandler_ps1 = @"
   New-Item "$env:ProgramFiles\RustDesk\urlhandler.ps1" > null
   Set-Content "$env:ProgramFiles\RustDesk\urlhandler.ps1" $urlhandler_ps1 > null
   Invoke-Ps2Exe "$env:ProgramFiles\RustDesk\urlhandler.ps1" "$env:ProgramFiles\RustDesk\RustDeskURLLauncher.exe" > null
-  Remove-Item "$env:ProgramFiles\RustDesk\urlhandler.ps1" > null
 
   Start-Sleep -s 20
 
   # Cleanup Tempfiles
+  Remove-Item "$env:ProgramFiles\RustDesk\urlhandler.ps1" > null
   cd $env:Temp
-  Remove-Item $env:Temp\rustdesk -Recurse
+  Remove-Item $env:Temp\rustdesk -Recurse > null
+  Remove-Item $env:Temp\rustdesk.zip > null
 }
 
 # Write config
@@ -90,13 +91,18 @@ api-server = 'https://wanipreg'
 enable-audio = 'N'
 "@
 
-New-Item $env:AppData\RustDesk\config\RustDesk2.toml
-Set-Content $env:AppData\RustDesk\config\RustDesk2.toml $RustDesk2_toml
-New-Item $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml
-Set-Content $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml $RustDesk2_toml
+If (!(Test-Path $env:AppData\RustDesk\config\RustDesk2.toml)) {
+  New-Item $env:AppData\RustDesk\config\RustDesk2.toml > null
+}
+Set-Content $env:AppData\RustDesk\config\RustDesk2.toml $RustDesk2_toml > null
+
+If (!(Test-Path $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml)) {
+  New-Item $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml > null
+}
+Set-Content $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml $RustDesk2_toml > null
 
 $random_pass = (-join ((65..90) + (97..122) | Get-Random -Count 24 | % {[char]$_}))
-start "$env:ProgramFiles\RustDesk\RustDesk.exe" "--password $random_pass"
+Start "$env:ProgramFiles\RustDesk\RustDesk.exe" "--password $random_pass"
 
 Start-Sleep -s 5
 
@@ -119,5 +125,5 @@ If (!("$env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\
 
 Start-Sleep -s 10
 
-taskkill /IM "rustdesk.exe" /F > null
-net start rustdesk > null
+Stop-Process -Name RustDesk -Force > null
+Start-Service -Name RustDesk > null

--- a/WindowsAgentAIOInstall.ps1
+++ b/WindowsAgentAIOInstall.ps1
@@ -18,6 +18,7 @@ function OutputIDandPW([String]$rustdesk_id, [String]$rustdesk_pw) {
   Write-Output("")
   Write-Output("  RustDesk-ID:       $rustdesk_id")
   Write-Output("  RustDesk-Password: $rustdesk_pw")
+  Write-Output("")
 }
 
 If (!(Test-Path $env:Temp)) {

--- a/WindowsAgentAIOInstall.ps1
+++ b/WindowsAgentAIOInstall.ps1
@@ -2,77 +2,117 @@ $ErrorActionPreference= 'silentlycontinue'
 #Requires -RunAsAdministrator
 # Replace wanipreg and keyreg with the relevant info for your install. IE wanipreg becomes your rustdesk server IP or DNS and keyreg becomes your public key.
 
-If (!(test-path "c:\temp")) {
-    New-Item -ItemType Directory -Force -Path "c:\temp" > null
+$restdesk_url = 'https://github.com/rustdesk/rustdesk/releases/latest'
+$request = [System.Net.WebRequest]::Create($restdesk_url)
+$response = $request.GetResponse()
+$realTagUrl = $response.ResponseUri.OriginalString
+$restdesk_version = $realTagUrl.split('/')[-1].Trim('v')
+Write-Output("Installing RestDesk version $restdesk_version")
+
+function OutputIDandPW([String]$rustdesk_id, [String]$rustdesk_pw) {
+  Write-Output("######################################################")
+  Write-Output("#                                                    #")
+  Write-Output("# CONNECTION PARAMETERS:                             #")
+  Write-Output("#                                                    #")
+  Write-Output("######################################################")
+  Write-Output("")
+  Write-Output("  RustDesk-ID:       $rustdesk_id")
+  Write-Output("  RustDesk-Password: $rustdesk_pw")
 }
-cd c:\temp
 
-If (!(test-path "C:\Program Files\Rustdesk\RustDesk.exe")) {
-cd c:\temp
+If (!(Test-Path $env:Temp)) {
+  New-Item -ItemType Directory -Force -Path $env:Temp > null
+}
 
-Invoke-WebRequest https://github.com/rustdesk/rustdesk/releases/download/1.1.9/rustdesk-1.1.9-windows_x64.zip -Outfile rustdesk.zip
+cd $env:Temp
 
-expand-archive rustdesk.zip
-cd rustdesk
-start .\rustdesk-1.1.9-putes.exe --silent-install
+If (!(Test-Path "C:\Program Files\Rustdesk\RustDesk.exe")) {
 
-# Set URL Handler
-New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk" > null
-Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk" -Name "(Default)" -Value "URL:RustDesk Protocol" > null
-New-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk" -Name "URL Protocol" -Type STRING > null
-New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\DefaultIcon" > null
-Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk\DefaultIcon" -Name "(Default)" -Value "RustDesk.exe,0" > null
-New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell" > null 
-New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell\open" > null 
-New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell\open\command" > null 
-Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell\open\command" -Name "(Default)" -Value '"C:\Program Files\RustDesk\RustDeskURLLauncher.exe" "%1"' > null
-New-Item "C:\Program Files\RustDesk\urlhandler.ps1" > null
-Set-Content "C:\Program Files\RustDesk\urlhandler.ps1" "`$url_handler = `$args[0]`n`$rustdesk_id = `$url_handler -creplace '(?s)^.*\:',''`nStart-Process -FilePath 'C:\Program Files\RustDesk\rustdesk.exe' -ArgumentList ""--connect `$rustdesk_id""" > null
-Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force  > null
-Install-Module ps2exe -Force  > null
-Invoke-ps2exe "C:\Program Files\RustDesk\urlhandler.ps1" "C:\Program Files\RustDesk\RustDeskURLLauncher.exe" > null
-Remove-Item "C:\Program Files\RustDesk\urlhandler.ps1" > null
+  cd $env:Temp
 
-Start-sleep -s 20
+  Invoke-WebRequest https://github.com/rustdesk/rustdesk/releases/download/$restdesk_version/rustdesk-$restdesk_version-windows_x64.zip -Outfile rustdesk.zip
+
+  Expand-Archive rustdesk.zip
+  cd rustdesk
+  start .\rustdesk-$restdesk_version-putes.exe --silent-install
+
+  # Set URL Handler
+  New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk" > null
+  Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk" -Name "(Default)" -Value "URL:RustDesk Protocol" > null
+  New-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk" -Name "URL Protocol" -Type STRING > null
+
+  New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\DefaultIcon" > null
+  Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk\DefaultIcon" -Name "(Default)" -Value "RustDesk.exe,0" > null
+
+  New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell" > null
+  New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell\open" > null
+  New-Item -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell\open\command" > null
+  $rustdesklauncher = '"' + $env:ProgramFiles + '\RustDesk\RustDeskURLLauncher.exe" %1"'
+  Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\RustDesk\shell\open\command" -Name "(Default)" -Value $rustdesklauncher > null
+
+  Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force  > null
+  Install-Module ps2exe -Force  > null
+
+$urlhandler_ps1 = @"
+  `$url_handler = `$args[0]
+  `$rustdesk_id = `$url_handler -creplace '(?s)^.*\:',''
+  Start-Process -FilePath 'C:\Program Files\RustDesk\rustdesk.exe' -ArgumentList "--connect `$rustdesk_id"
+"@
+
+  New-Item "$env:ProgramFiles\RustDesk\urlhandler.ps1" > null
+  Set-Content "$env:ProgramFiles\RustDesk\urlhandler.ps1" $urlhandler_ps1 > null
+  Invoke-Ps2Exe "$env:ProgramFiles\RustDesk\urlhandler.ps1" "$env:ProgramFiles\RustDesk\RustDeskURLLauncher.exe" > null
+  Remove-Item "$env:ProgramFiles\RustDesk\urlhandler.ps1" > null
+
+  Start-Sleep -s 20
 }
 
 # Write config
-$username = ((Get-WMIObject -ClassName Win32_ComputerSystem).Username).Split('\')[1]
-New-Item C:\Users\$username\AppData\Roaming\RustDesk\config\RustDesk2.toml
-Set-Content C:\Users\$username\AppData\Roaming\RustDesk\config\RustDesk2.toml "rendezvous_server = 'wanipreg' `nnat_type = 1`nserial = 0`n`n[options]`ncustom-rendezvous-server = 'wanipreg'`nkey = 'keyreg'`nrelay-server = 'wanipreg'`napi-server = 'https://wanipreg'"
+$RustDesk2_toml = @"
+rendezvous_server = 'wanipreg'
+nat_type = 1
+serial = 0
+
+[options]
+custom-rendezvous-server = 'wanipreg'
+key =  keyreg'
+relay-server = 'wanipreg'
+api-server = 'https://wanipreg'
+enable-audio = 'N'
+"@
+
+New-Item $env:AppData\RustDesk\config\RustDesk2.toml
+Set-Content $env:AppData\RustDesk\config\RustDesk2.toml $RustDesk2_toml
 New-Item C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml
-Set-Content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml "rendezvous_server = 'wanipreg' `nnat_type = 1`nserial = 0`n`n[options]`ncustom-rendezvous-server = 'wanipreg'`nkey = 'keyreg'`nrelay-server = 'wanipreg'`napi-server = 'https://wanipreg'"
+Set-Content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml $RustDesk2_toml
 
-$rdpass = (-join ((65..90) + (97..122) | Get-Random -Count 8 | % {[char]$_}))
-start "C:\Program Files\RustDesk\RustDesk.exe" "--password $rdpass"
+$random_pass = (-join ((65..90) + (97..122) | Get-Random -Count 24 | % {[char]$_}))
+start "C:\Program Files\RustDesk\RustDesk.exe" "--password $random_pass"
 
-Start-sleep -s 5
+Start-Sleep -s 5
 
 # Get RustDesk ID
-
 If (!("C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml")) {
-$username = ((Get-WMIObject -ClassName Win32_ComputerSystem).Username).Split('\')[1]
-$rustid=(Get-content C:\Users\$username\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
-$rustid = $rustid.Split("'")[1]
+  $rustdesk_id = (Get-Content $env:AppData\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
+  $rustdesk_id = $rustdesk_id.Split("'")[1]
+  $rustdesk_pw = (Get-Content $env:AppData\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
+  $rustdesk_pw = $rustdesk_pw.Split("'")[1]
+  Write-Output("Config file found in user folder")
 
-$rustpword = (Get-content C:\Users\$username\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
-$rustpword = $rustpword.Split("'")[1]
-Write-output "$rustid"
-Write-output "$rustpword"
-Write-output "Config file found in user folder"
-}
-else {
-$rustid=(Get-content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
-$rustid = $rustid.Split("'")[1]
+  OutputIDandPW $rustdesk_id $rustdesk_pw
 
-$rustpword = (Get-content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
-$rustpword = $rustpword.Split("'")[1]
-Write-output "$rustid"
-Write-output "$rustpword"
-Write-output "Config file found in windows service folder"
+} Else {
+  $rustdesk_id = (Get-Content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
+  $rustdesk_id = $rustdesk_id.Split("'")[1]
+  $rustdesk_pw = (Get-Content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
+  $rustdesk_pw = $rustdesk_pw.Split("'")[1]
+  Write-Output "Config file found in windows service folder"
+
+  OutputIDandPW $rustdesk_id $rustdesk_pw
+
 }
 
-Start-sleep -s 10
+Start-Sleep -s 10
 
 taskkill /IM "rustdesk.exe" /F > null
 net start rustdesk > null

--- a/WindowsAgentAIOInstall.ps1
+++ b/WindowsAgentAIOInstall.ps1
@@ -25,8 +25,6 @@ If (!(Test-Path $env:Temp)) {
   New-Item -ItemType Directory -Force -Path $env:Temp > null
 }
 
-cd $env:Temp
-
 If (!(Test-Path "$env:ProgramFiles\Rustdesk\RustDesk.exe")) {
 
   cd $env:Temp
@@ -109,18 +107,14 @@ If (!("$env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\
   $rustdesk_pw = (Get-Content $env:AppData\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
   $rustdesk_pw = $rustdesk_pw.Split("'")[1]
   Write-Output("Config file found in user folder")
-
   OutputIDandPW $rustdesk_id $rustdesk_pw
-
 } Else {
   $rustdesk_id = (Get-Content $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
   $rustdesk_id = $rustdesk_id.Split("'")[1]
   $rustdesk_pw = (Get-Content $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
   $rustdesk_pw = $rustdesk_pw.Split("'")[1]
   Write-Output "Config file found in windows service folder"
-
   OutputIDandPW $rustdesk_id $rustdesk_pw
-
 }
 
 Start-Sleep -s 10

--- a/WindowsAgentAIOInstall.ps1
+++ b/WindowsAgentAIOInstall.ps1
@@ -31,7 +31,13 @@ If (!(Test-Path "C:\Program Files\Rustdesk\RustDesk.exe")) {
 
   cd $env:Temp
 
-  Invoke-WebRequest https://github.com/rustdesk/rustdesk/releases/download/$restdesk_version/rustdesk-$restdesk_version-windows_x64.zip -Outfile rustdesk.zip
+  If ([Environment]::Is64BitOperatingSystem) {
+    $os_arch = "x64"
+  } Else {
+    $os_arch = "x32"
+  }
+
+  Invoke-WebRequest https://github.com/rustdesk/rustdesk/releases/download/$restdesk_version/rustdesk-$restdesk_version-windows_$os_arch.zip -Outfile rustdesk.zip
 
   Expand-Archive rustdesk.zip
   cd rustdesk
@@ -66,6 +72,10 @@ $urlhandler_ps1 = @"
   Remove-Item "$env:ProgramFiles\RustDesk\urlhandler.ps1" > null
 
   Start-Sleep -s 20
+
+  # Cleanup Tempfiles
+  cd $env:Temp
+  Remove-Item $env:Temp\rustdesk -Recurse
 }
 
 # Write config

--- a/WindowsAgentAIOInstall.ps1
+++ b/WindowsAgentAIOInstall.ps1
@@ -27,7 +27,7 @@ If (!(Test-Path $env:Temp)) {
 
 cd $env:Temp
 
-If (!(Test-Path "C:\Program Files\Rustdesk\RustDesk.exe")) {
+If (!(Test-Path "$env:ProgramFiles\Rustdesk\RustDesk.exe")) {
 
   cd $env:Temp
 
@@ -63,7 +63,7 @@ If (!(Test-Path "C:\Program Files\Rustdesk\RustDesk.exe")) {
 $urlhandler_ps1 = @"
   `$url_handler = `$args[0]
   `$rustdesk_id = `$url_handler -creplace '(?s)^.*\:',''
-  Start-Process -FilePath 'C:\Program Files\RustDesk\rustdesk.exe' -ArgumentList "--connect `$rustdesk_id"
+  Start-Process -FilePath '$env:ProgramFiles\RustDesk\rustdesk.exe' -ArgumentList "--connect `$rustdesk_id"
 "@
 
   New-Item "$env:ProgramFiles\RustDesk\urlhandler.ps1" > null
@@ -94,16 +94,16 @@ enable-audio = 'N'
 
 New-Item $env:AppData\RustDesk\config\RustDesk2.toml
 Set-Content $env:AppData\RustDesk\config\RustDesk2.toml $RustDesk2_toml
-New-Item C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml
-Set-Content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml $RustDesk2_toml
+New-Item $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml
+Set-Content $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml $RustDesk2_toml
 
 $random_pass = (-join ((65..90) + (97..122) | Get-Random -Count 24 | % {[char]$_}))
-start "C:\Program Files\RustDesk\RustDesk.exe" "--password $random_pass"
+start "$env:ProgramFiles\RustDesk\RustDesk.exe" "--password $random_pass"
 
 Start-Sleep -s 5
 
 # Get RustDesk ID
-If (!("C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml")) {
+If (!("$env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml")) {
   $rustdesk_id = (Get-Content $env:AppData\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
   $rustdesk_id = $rustdesk_id.Split("'")[1]
   $rustdesk_pw = (Get-Content $env:AppData\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
@@ -113,9 +113,9 @@ If (!("C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\R
   OutputIDandPW $rustdesk_id $rustdesk_pw
 
 } Else {
-  $rustdesk_id = (Get-Content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
+  $rustdesk_id = (Get-Content $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("id") })
   $rustdesk_id = $rustdesk_id.Split("'")[1]
-  $rustdesk_pw = (Get-Content C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
+  $rustdesk_pw = (Get-Content $env:WinDir\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml | Where-Object { $_.Contains("password") })
   $rustdesk_pw = $rustdesk_pw.Split("'")[1]
   Write-Output "Config file found in windows service folder"
 


### PR DESCRIPTION
**little refactoring:**
- get latest client from github depending on os architecture
- replace $username and use $env:AppData (installations via RDP will fail otherwise)
- use $env:Temp instead of C:\temp (there are rare cases when windows is not installed on c: plus we already have an environment variable defined for this)
- use $env:ProgramFiles instead of hardcoded path (see $env:Temp)
- use $env:WinDir instead of hardcoded path (see $env:Temp)
- use a function to output ID and Password
- use a variable for content of RustDesk2.toml file
- use a longer password (8 chars is definitely not enough, especially for unattended access)
- cleanup temp files
- try to use native powershell commands Stop-Process instead of "taskkill" and Start-Service instead of "net start"
